### PR TITLE
refactor(build stages): internal build should be after pre build

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,17 @@ const { clear, debug } = flags;
     config.hooks.addHooks(hooks);
 
     // trigger provider setup
+    // provider specific pre build
+    await config.hooks.callHook(`prebuild`, providerConfig);
+
+    // general internal build
     await configSetup();
     await installDependecies();
-    await config.hooks.callHook(`prebuild`, providerConfig);
+
+    // provider specific build
     await config.hooks.callHook(`build`, providerConfig);
+
+    // provider specific post build
     await config.hooks.callHook(`postbuild`, providerConfig);
 
     config.useDocker && (await useTool());


### PR DESCRIPTION
This PR reworks the build stages to ensure internal build stage is done only after providers pre build. 